### PR TITLE
embassy-rp: Add Drop implementation to InputFuture for cancellation safety

### DIFF
--- a/embassy-rp/src/gpio.rs
+++ b/embassy-rp/src/gpio.rs
@@ -364,6 +364,26 @@ impl<'d> Future for InputFuture<'d> {
     }
 }
 
+impl<'d> Drop for InputFuture<'d> {
+    fn drop(&mut self) {
+        // When the future is dropped (cancelled), we need to clear all interrupt
+        // enables for this pin to ensure cancellation safety. This prevents:
+        // 1. Spurious interrupts from firing after cancellation
+        // 2. Edge events from being "consumed" during cancellation windows
+        // 3. Hardware state inconsistency between cancelled and fresh futures
+        let pin_group = (self.pin.pin() % 8) as usize;
+        self.pin
+            .int_proc()
+            .inte((self.pin.pin() / 8) as usize)
+            .write_clear(|w| {
+                w.set_edge_high(pin_group, true);
+                w.set_edge_low(pin_group, true);
+                w.set_level_high(pin_group, true);
+                w.set_level_low(pin_group, true);
+            });
+    }
+}
+
 /// GPIO output driver.
 #[derive(Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]


### PR DESCRIPTION
Implements proper cleanup when GPIO edge/level detection futures are
cancelled. Without this Drop implementation, cancelled InputFutures
would leave interrupt enables (INTE bits) set in hardware, causing:

1. Spurious interrupts to fire after future cancellation
2. Edge events to be "consumed" during cancellation windows, making
   them invisible to subsequent wait operations
3. Inconsistent hardware state between cancelled and fresh futures

The Drop implementation clears all interrupt enables for the pin,
similar to the interrupt handler cleanup, ensuring that cancelled
futures don't leave hardware in an active monitoring state.

This makes InputFuture (and by extension all wait_for_* methods on
Flex, Input, and OutputOpenDrain) properly cancellation-safe, matching
the behavior of embassy-nrf's PortInputFuture.

Fixes cancellation safety for:
- wait_for_high() / wait_for_low()
- wait_for_rising_edge() / wait_for_falling_edge()
- wait_for_any_edge()